### PR TITLE
Adding /statusall endpoint, to get a status from all servers.txt entries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,8 @@ Run
 npm start
 ```
 
+## get a server status
+
 Now you can make a request like this:
 
 `localhost:8080/?ip=192.168.1.3&port=27015`
@@ -66,3 +68,12 @@ You can then access this information through `/servers`.
 ```
 ["192.168.1.1:27015","10.0.0.1:27015","1.1.1.1:27020"]
 ```
+
+### servers.txt statuses (statusall)
+
+If you're using a `servers.txt` file, you can make a request like this:
+
+`localhost:8080/statusall`
+
+If the `servers.txt` has valid RCON addresses, it will return an array of objects exact same as `get a server status` section,
+of all servers described on it.

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,31 @@ app.get("/servers", (req, res) => {
     }
 });
 
+app.get("/statusall", (req, res) => {
+    if (!fs.existsSync("./servers.txt")) {
+        res.status(200).send({
+            status: "error",
+            message: "no servers.txt found"
+        })
+    }
+    else {
+        const data = fs.readFileSync("./servers.txt").toString();
+        const servers = data.split(/\r?\n/)
+
+        Promise.all(servers.map(server => {
+            let parts = server.split(/\:/)
+            return getStatus(parts[0], parts[1])
+        })).then(allServersResult => {
+            res.status(200).send(allServersResult);
+        }, (error) => {
+            res.status(200).send({
+                status: "error",
+                message: error.toString()
+            });
+        });
+    }
+})
+
 function start() {
     // Start http server
     http.createServer(app).listen(http_port, () => {


### PR DESCRIPTION
I've implemented a /statusall endpoint.

It returns an array of server status for each entry on `servers.txt` file.